### PR TITLE
Change zsh completion path to fit debian-based distributions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ assets = [
 	["target/release/tldr", "usr/bin/", "755"],
 	["tldr.1", "usr/share/man/man1/", "644"],
 	["completions/tldr.bash", "usr/share/bash-completion/completions/tldr", "644"],
-	["completions/_tldr", "usr/share/zsh/site-functions/", "644"],
+	["completions/_tldr", "usr/share/zsh/vendor-completions/", "644"],
 	["completions/tldr.fish", "usr/share/fish/vendor_completions.d/", "644"],
 	["LICENSE", "usr/share/licenses/tlrc", "644"]
 ]


### PR DESCRIPTION
This should fix the zsh autocompletion issue mentioned [here](https://github.com/tldr-pages/tlrc/issues/84#issuecomment-3356937023).

From what I can tell this should be the correct path for debian-based distributions, while the bash and fish completion paths should already be correct.