### PR TITLE
feat: add aarch64 target for macOS to build-release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -51,6 +51,9 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
 
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
           - target: x86_64-pc-windows-msvc
             os: windows-latest
 


### PR DESCRIPTION
Reason:
Allow m-series macs to run the program directly without installing Rosetta

Tested:
- the workflow completes on github
- the binary runs successfully on an aarch64 mac (m1 2020)

