### PR TITLE
feat: Add support for personal repositories ("taps") to the client spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ max_age = 336 # 336 hours = 2 weeks
 # Example: ["de", "pl"]
 languages = []
 
+# Optional personal git-backed repositories ("taps").
+# Each tap can contribute additional examples appended below official pages.
+[[taps]]
+name = "personal"
+url = "https://example.com/your/tldr-pages.git"
+# Optional branch to track.
+# branch = "main"
+# Disable this tap without removing it from config.
+enabled = true
+
 [output]
 # Show the title in the rendered page.
 show_title = true
@@ -266,6 +276,18 @@ description.color = "default"
 bullet.color = "green"
 example.color = "red"
 placeholder.color = "default"
+```
+
+### Personal repository commands
+
+Tlrc can manage personal repositories ("taps") from the command line:
+
+```shell
+tldr --tap-list
+tldr --tap-add personal https://example.com/your/tldr-pages.git
+tldr --tap-update personal
+tldr --tap-update-all
+tldr --tap-remove personal
 ```
 
 [latest-release]: https://github.com/tldr-pages/tlrc/releases/latest

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::process;
 
 /// The version of the tldr client specification being implemented.
-const CLIENT_SPEC: &str = "2.3";
+const CLIENT_SPEC: &str = "2.4";
 
 fn is_debug_build() -> bool {
     env::var("PROFILE").unwrap() == "debug"

--- a/src/args.rs
+++ b/src/args.rs
@@ -71,6 +71,26 @@ pub struct Cli {
     #[arg(short, long, group = "operations")]
     pub info: bool,
 
+    /// List configured personal repositories ("taps").
+    #[arg(long, group = "operations")]
+    pub tap_list: bool,
+
+    /// Add a personal repository ("tap") by name and git URL.
+    #[arg(long, num_args = 2, value_names = ["NAME", "URL"], group = "operations")]
+    pub tap_add: Option<Vec<String>>,
+
+    /// Remove a configured personal repository ("tap").
+    #[arg(long, value_name = "NAME", group = "operations")]
+    pub tap_remove: Option<String>,
+
+    /// Update a configured personal repository ("tap").
+    #[arg(long, value_name = "NAME", group = "operations")]
+    pub tap_update: Option<String>,
+
+    /// Update all configured personal repositories ("taps").
+    #[arg(long, group = "operations")]
+    pub tap_update_all: bool,
+
     /// Render the specified markdown file.
     #[arg(short, long, group = "operations", value_name = "FILE")]
     pub render: Option<PathBuf>,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,6 +4,7 @@ use std::ffi::OsString;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufWriter, Cursor, Write};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 use log::{debug, info, warn};
@@ -13,6 +14,7 @@ use yansi::Paint;
 use zip::ZipArchive;
 
 use crate::config::Config;
+use crate::config::TapConfig;
 use crate::error::{Error, Result};
 use crate::util::{self, info_end, info_start, Dedup};
 
@@ -20,6 +22,7 @@ pub const ENGLISH_DIR: &str = "pages.en";
 const CHECKSUM_FILE: &str = "tldr.sha256sums";
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), '/', env!("CARGO_PKG_VERSION"));
 const HTTP_TIMEOUT: Option<Duration> = Some(Duration::from_secs(10));
+const TAPS_DIR: &str = "taps";
 
 type PagesArchive = ZipArchive<Cursor<Vec<u8>>>;
 
@@ -46,6 +49,121 @@ impl<'a> Cache<'a> {
     /// Return `true` if the specified subdirectory exists in the cache.
     pub fn subdir_exists(&self, sd: &str) -> bool {
         self.dir.join(sd).is_dir()
+    }
+
+    fn taps_dir(&self) -> PathBuf {
+        self.dir.join(TAPS_DIR)
+    }
+
+    fn sanitized_tap_name(name: &str) -> String {
+        let mut out = String::with_capacity(name.len());
+        for ch in name.chars() {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+                out.push(ch);
+            } else {
+                out.push('_');
+            }
+        }
+        if out.is_empty() {
+            "_".to_string()
+        } else {
+            out
+        }
+    }
+
+    pub fn tap_repo_path(&self, tap_name: &str) -> PathBuf {
+        self.taps_dir().join(Self::sanitized_tap_name(tap_name))
+    }
+
+    fn run_git(cmd: &mut Command, context: &str) -> Result<()> {
+        let output = cmd
+            .output()
+            .map_err(|e| Error::new(format!("failed to run git for {context}: {e}")))?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        if stderr.is_empty() {
+            Err(Error::new(format!("git command failed for {context}")))
+        } else {
+            Err(Error::new(format!(
+                "git command failed for {context}: {stderr}"
+            )))
+        }
+    }
+
+    pub fn sync_tap(&self, tap: &TapConfig) -> Result<()> {
+        if tap.name.is_empty() {
+            return Err(Error::new("tap name cannot be empty"));
+        }
+        if tap.url.is_empty() {
+            return Err(Error::new(format!("tap '{}' has an empty URL", tap.name)));
+        }
+
+        fs::create_dir_all(self.taps_dir())?;
+        let repo_path = self.tap_repo_path(&tap.name);
+        let branch = tap.branch.as_deref();
+
+        if repo_path.join(".git").is_dir() {
+            info!("updating tap '{}'...", tap.name);
+
+            let mut fetch = Command::new("git");
+            fetch
+                .current_dir(&repo_path)
+                .args(["fetch", "--all", "--prune"]);
+            Self::run_git(&mut fetch, &format!("fetching tap '{}'", tap.name))?;
+
+            if let Some(branch) = branch {
+                let mut checkout = Command::new("git");
+                checkout.current_dir(&repo_path).args(["checkout", branch]);
+                Self::run_git(
+                    &mut checkout,
+                    &format!("checking out '{branch}' in tap '{}'", tap.name),
+                )?;
+
+                let mut pull = Command::new("git");
+                pull.current_dir(&repo_path)
+                    .args(["pull", "--ff-only", "origin", branch]);
+                Self::run_git(
+                    &mut pull,
+                    &format!("pulling branch '{branch}' for tap '{}'", tap.name),
+                )?;
+            } else {
+                let mut pull = Command::new("git");
+                pull.current_dir(&repo_path).args(["pull", "--ff-only"]);
+                Self::run_git(&mut pull, &format!("pulling tap '{}'", tap.name))?;
+            }
+        } else {
+            if repo_path.exists() {
+                return Err(Error::new(format!(
+                    "cannot clone tap '{}': '{}' exists but is not a git repository",
+                    tap.name,
+                    repo_path.display()
+                )));
+            }
+
+            info!("cloning tap '{}'...", tap.name);
+            let mut clone = Command::new("git");
+            clone.arg("clone").arg("--depth").arg("1");
+            if let Some(branch) = branch {
+                clone.arg("--branch").arg(branch);
+            }
+            clone.arg(&tap.url).arg(&repo_path);
+            Self::run_git(&mut clone, &format!("cloning tap '{}'", tap.name))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn remove_tap_checkout(&self, tap_name: &str) -> Result<()> {
+        let repo_path = self.tap_repo_path(tap_name);
+        if repo_path.exists() {
+            fs::remove_dir_all(repo_path)?;
+        }
+        Ok(())
     }
 
     /// Send a GET request with the provided agent and return the response body.
@@ -381,6 +499,42 @@ impl<'a> Cache<'a> {
         None
     }
 
+    /// Find a page for the given platform under a custom base directory.
+    fn find_page_for_base<P>(
+        &self,
+        base_dir: &Path,
+        fname: &str,
+        platform: P,
+        lang_dirs: &[String],
+    ) -> Option<PathBuf>
+    where
+        P: AsRef<Path>,
+    {
+        for lang_dir in lang_dirs {
+            let path = base_dir.join(lang_dir).join(&platform).join(fname);
+            debug!("trying path: {path:?}");
+            if path.is_file() {
+                debug!("page found");
+                return Some(path);
+            }
+        }
+        None
+    }
+
+    fn tap_language_dirs(languages: &[String]) -> Vec<String> {
+        let mut dirs = Vec::with_capacity(languages.len() + 1);
+        for lang in languages {
+            if lang == "en" {
+                dirs.push("pages".to_string());
+                dirs.push(ENGLISH_DIR.to_string());
+            } else {
+                dirs.push(format!("pages.{lang}"));
+            }
+        }
+        dirs.dedup_nosort();
+        dirs
+    }
+
     /// Find all pages with the given name.
     pub fn find(&self, name: &str, languages: &[String], platform: &str) -> Result<Vec<PathBuf>> {
         // https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md#page-resolution
@@ -436,6 +590,66 @@ impl<'a> Cache<'a> {
         }
 
         debug!("found {} page(s)", result.len());
+        Ok(result)
+    }
+
+    /// Find matching pages in enabled taps.
+    pub fn find_in_taps(
+        &self,
+        name: &str,
+        languages: &[String],
+        platform: &str,
+        taps: &[TapConfig],
+    ) -> Result<Vec<PathBuf>> {
+        let platforms = self.get_platforms_and_check(platform)?;
+        let file = format!("{name}.md");
+        let mut lang_dirs = Self::tap_language_dirs(languages);
+        lang_dirs.dedup_nosort();
+
+        let mut result = Vec::new();
+
+        for tap in taps {
+            if !tap.enabled {
+                continue;
+            }
+
+            let repo_root = self.tap_repo_path(&tap.name);
+            if !repo_root.is_dir() {
+                debug!(
+                    "tap '{}' is configured but repository is missing locally at '{}'",
+                    tap.name,
+                    repo_root.display()
+                );
+                continue;
+            }
+
+            let mut tap_page = None;
+
+            if platform != "common" {
+                tap_page = self.find_page_for_base(&repo_root, &file, platform, &lang_dirs);
+            }
+
+            if tap_page.is_none() {
+                tap_page = self.find_page_for_base(&repo_root, &file, "common", &lang_dirs);
+            }
+
+            if tap_page.is_none() {
+                for alt_platform in platforms {
+                    if alt_platform == platform || alt_platform == "common" {
+                        continue;
+                    }
+                    tap_page = self.find_page_for_base(&repo_root, &file, alt_platform, &lang_dirs);
+                    if tap_page.is_some() {
+                        break;
+                    }
+                }
+            }
+
+            if let Some(page) = tap_page {
+                result.push(page);
+            }
+        }
+
         Ok(result)
     }
 
@@ -760,5 +974,66 @@ mod tests {
         let s = "xyz    pages.en.zip\nzyx   pages.xy.zip\nabc   someotherfile\ncba  index.json";
         let map = HashMap::from([("en", "xyz"), ("xy", "zyx")]);
         assert_eq!(Cache::parse_sumfile(s).unwrap(), map);
+    }
+
+    #[test]
+    fn find_pages_in_taps() {
+        let tmpdir = prepare(&[
+            "pages.en/common/a.md",
+            "pages.en/linux/a.md",
+            "taps/personal/pages/common/a.md",
+            "taps/disabled/pages/common/a.md",
+        ]);
+        let c = Cache::new(tmpdir.path());
+
+        let taps = vec![
+            TapConfig {
+                name: "personal".to_string(),
+                url: "https://example.com/personal.git".to_string(),
+                branch: None,
+                enabled: true,
+            },
+            TapConfig {
+                name: "disabled".to_string(),
+                url: "https://example.com/disabled.git".to_string(),
+                branch: None,
+                enabled: false,
+            },
+        ];
+
+        let found = c
+            .find_in_taps("a", &["en".to_string()], "linux", &taps)
+            .unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(found[0].ends_with("taps/personal/pages/common/a.md"));
+    }
+
+    #[test]
+    fn tap_path_is_sanitized() {
+        let tmpdir = prepare(&["pages.en/common/a.md"]);
+        let c = Cache::new(tmpdir.path());
+        let path = c.tap_repo_path("my tap/name");
+        assert!(path.ends_with("taps/my_tap_name"));
+    }
+
+    #[test]
+    fn sync_tap_validates_required_fields() {
+        let tmpdir = prepare(&["pages.en/common/a.md"]);
+        let c = Cache::new(tmpdir.path());
+        let empty_name = TapConfig {
+            name: String::new(),
+            url: "https://example.com/repo.git".to_string(),
+            branch: None,
+            enabled: true,
+        };
+        assert!(c.sync_tap(&empty_name).is_err());
+
+        let empty_url = TapConfig {
+            name: "personal".to_string(),
+            url: String::new(),
+            branch: None,
+            enabled: true,
+        };
+        assert!(c.sync_tap(&empty_url).is_err());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,6 +239,35 @@ pub struct CacheConfig {
     pub languages: Vec<String>,
 }
 
+fn default_tap_enabled() -> bool {
+    true
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields, default)]
+pub struct TapConfig {
+    /// Unique tap name.
+    pub name: String,
+    /// Git URL.
+    pub url: String,
+    /// Optional branch to track.
+    pub branch: Option<String>,
+    /// If false, this tap is ignored during lookup and updates.
+    #[serde(default = "default_tap_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for TapConfig {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            url: String::new(),
+            branch: None,
+            enabled: true,
+        }
+    }
+}
+
 impl Default for CacheConfig {
     fn default() -> Self {
         Self {
@@ -329,6 +358,7 @@ pub struct Config {
     pub output: OutputConfig,
     pub indent: IndentConfig,
     pub style: StyleConfig,
+    pub taps: Vec<TapConfig>,
 }
 
 impl Config {
@@ -375,6 +405,11 @@ impl Config {
         })
     }
 
+    /// Resolve the config file path for loading/saving.
+    pub fn resolve_path(cli_config_path: Option<&Path>) -> PathBuf {
+        cli_config_path.map_or_else(Self::locate, Path::to_path_buf)
+    }
+
     /// Get the default path to the config file.
     pub fn locate() -> PathBuf {
         env::var_os("TLRC_CONFIG").map_or_else(
@@ -386,6 +421,15 @@ impl Config {
             },
             PathBuf::from,
         )
+    }
+
+    /// Save config to a file path.
+    pub fn save_to(&self, path: &Path) -> Result<()> {
+        fs::create_dir_all(path.parent().ok_or_else(|| {
+            Error::new("cannot create the config directory: the path has only one component")
+        })?)?;
+        fs::write(path, toml::ser::to_string_pretty(self)?)?;
+        Ok(())
     }
 
     /// Print the default path to the config file and create the config directory.
@@ -418,5 +462,34 @@ impl Config {
     /// Convert the number of hours from config to a `Duration`.
     pub const fn cache_max_age(&self) -> Duration {
         Duration::from_secs(self.cache.max_age * 60 * 60)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_taps() {
+        let cfg = toml::from_str::<Config>(
+            r#"
+                [[taps]]
+                name = "local"
+                url = "https://example.com/tldr-local.git"
+
+                [[taps]]
+                name = "team"
+                url = "ssh://git@example.com/team/tldr.git"
+                branch = "main"
+                enabled = false
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.taps.len(), 2);
+        assert_eq!(cfg.taps[0].name, "local");
+        assert!(cfg.taps[0].enabled);
+        assert_eq!(cfg.taps[1].branch.as_deref(), Some("main"));
+        assert!(!cfg.taps[1].enabled);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -130,5 +130,6 @@ macro_rules! from_impl {
 
 from_impl! { io::Error, Io }
 from_impl! { toml::de::Error, ParseToml }
+from_impl! { toml::ser::Error, ParseToml }
 from_impl! { ureq::Error, Download }
 from_impl! { zip::result::ZipError, Download }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod error;
 mod output;
 mod util;
 
+use std::io::{self, Write};
 use std::process::ExitCode;
 
 use clap::Parser;
@@ -13,7 +14,7 @@ use yansi::Paint;
 
 use crate::args::Cli;
 use crate::cache::Cache;
-use crate::config::{Config, OptionStyle};
+use crate::config::{Config, OptionStyle, TapConfig};
 use crate::error::{Error, Result};
 use crate::output::PageRenderer;
 use crate::util::{init_color, Logger};
@@ -41,6 +42,30 @@ fn include_cli_in_config(cfg: &mut Config, cli: &Cli) {
     }
 }
 
+fn print_taps(cfg: &Config) -> Result<()> {
+    let mut stdout = io::stdout().lock();
+    if cfg.taps.is_empty() {
+        writeln!(stdout, "no taps configured")?;
+        return Ok(());
+    }
+
+    for tap in &cfg.taps {
+        let mut line = format!("{} -> {}", tap.name, tap.url);
+        if let Some(branch) = &tap.branch {
+            line.push_str(&format!(" (branch: {branch})"));
+        }
+        if !tap.enabled {
+            line.push_str(" [disabled]");
+        }
+        writeln!(stdout, "{line}")?;
+    }
+    Ok(())
+}
+
+fn find_tap<'a>(cfg: &'a Config, name: &str) -> Option<&'a TapConfig> {
+    cfg.taps.iter().find(|tap| tap.name == name)
+}
+
 fn run(cli: Cli) -> Result<()> {
     if cli.config_path {
         return Config::print_path();
@@ -52,6 +77,7 @@ fn run(cli: Cli) -> Result<()> {
 
     let mut cfg = Config::new(cli.config.as_deref())?;
     include_cli_in_config(&mut cfg, &cli);
+    let cfg_path = Config::resolve_path(cli.config.as_deref());
 
     if let Some(path) = cli.render {
         return PageRenderer::print(&path, &cfg);
@@ -63,6 +89,57 @@ fn run(cli: Cli) -> Result<()> {
     // unlike the one in the config.
     let languages = cli.languages.unwrap_or_else(|| cfg.cache.languages.clone());
     let cache = Cache::new(&cfg.cache.dir);
+
+    if cli.tap_list {
+        return print_taps(&cfg);
+    }
+
+    if let Some(tap_add) = &cli.tap_add {
+        let name = tap_add[0].clone();
+        let url = tap_add[1].clone();
+        if find_tap(&cfg, &name).is_some() {
+            return Err(Error::new(format!("tap '{name}' already exists")));
+        }
+
+        let tap = TapConfig {
+            name,
+            url,
+            branch: None,
+            enabled: true,
+        };
+        cache.sync_tap(&tap)?;
+        cfg.taps.push(tap.clone());
+        cfg.save_to(&cfg_path)?;
+        info!("tap '{}' added.", tap.name);
+        return Ok(());
+    }
+
+    if let Some(name) = &cli.tap_remove {
+        let old_len = cfg.taps.len();
+        cfg.taps.retain(|tap| &tap.name != name);
+        if cfg.taps.len() == old_len {
+            return Err(Error::new(format!("tap '{name}' does not exist")));
+        }
+
+        cache.remove_tap_checkout(name)?;
+        cfg.save_to(&cfg_path)?;
+        info!("tap '{name}' removed.");
+        return Ok(());
+    }
+
+    if let Some(name) = &cli.tap_update {
+        let tap = find_tap(&cfg, name)
+            .ok_or_else(|| Error::new(format!("tap '{name}' does not exist")))?;
+        cache.sync_tap(tap)?;
+        return Ok(());
+    }
+
+    if cli.tap_update_all {
+        for tap in cfg.taps.iter().filter(|tap| tap.enabled) {
+            cache.sync_tap(tap)?;
+        }
+        return Ok(());
+    }
 
     if cli.clean_cache {
         return cache.clean();
@@ -123,6 +200,7 @@ fn run(cli: Cli) -> Result<()> {
     } else {
         let page_name = cli.page.join("-").to_lowercase();
         let mut page_paths = cache.find(&page_name, &languages, platform)?;
+        let mut personal_paths = cache.find_in_taps(&page_name, &languages, platform, &cfg.taps)?;
         let forced_update_no_page = update_later && page_paths.is_empty();
         if forced_update_no_page {
             // Since the page hasn't been found and the cache is stale, disregard the defer option.
@@ -131,6 +209,7 @@ fn run(cli: Cli) -> Result<()> {
                 .update(&cfg.cache.mirror, &mut cfg.cache.languages)
                 .map_err(|e| e.describe(Error::DESC_AUTO_UPDATE_ERR))?;
             page_paths = cache.find(&page_name, &languages, platform)?;
+            personal_paths = cache.find_in_taps(&page_name, &languages, platform, &cfg.taps)?;
             // Reset the defer flag in order not to update twice.
             update_later = false;
         }
@@ -154,7 +233,7 @@ fn run(cli: Cli) -> Result<()> {
             };
         }
 
-        PageRenderer::print_cache_result(&page_paths, &cfg)?;
+        PageRenderer::print_cache_result_with_personal(&page_paths, &personal_paths, &cfg)?;
     }
 
     if update_later {

--- a/src/output.rs
+++ b/src/output.rs
@@ -17,6 +17,7 @@ const TITLE: &str = "# ";
 const DESC: &str = "> ";
 const BULLET: &str = "- ";
 const EXAMPLE: char = '`';
+const PERSONAL_TITLE: &str = "Personal additions";
 
 struct RenderStyles {
     title: Style,
@@ -362,6 +363,72 @@ impl<'a> PageRenderer<'a> {
         }
 
         Self::print(first, cfg)
+    }
+
+    pub fn print_cache_result_with_personal(
+        paths: &'a [PathBuf],
+        personal_paths: &'a [PathBuf],
+        cfg: &'a Config,
+    ) -> Result<()> {
+        Self::print_cache_result(paths, cfg)?;
+        if cfg.output.raw_markdown || personal_paths.is_empty() {
+            return Ok(());
+        }
+        Self::print_personal_additions(personal_paths, cfg)
+    }
+
+    fn print_personal_additions(personal_paths: &'a [PathBuf], cfg: &'a Config) -> Result<()> {
+        let mut stdout = BufWriter::new(io::stdout().lock());
+        let title_indent = " ".repeat(cfg.indent.title);
+        let bullet_indent = " ".repeat(cfg.indent.bullet);
+        let example_indent = " ".repeat(cfg.indent.example);
+        let title_style: Style = cfg.style.title.into();
+        let bullet_style: Style = cfg.style.bullet.into();
+        let example_style: Style = cfg.style.example.into();
+
+        if !cfg.output.compact {
+            writeln!(stdout)?;
+        }
+        writeln!(
+            stdout,
+            "{title_indent}{}",
+            PERSONAL_TITLE.paint(title_style)
+        )?;
+        if !cfg.output.compact {
+            writeln!(stdout)?;
+        }
+
+        for path in personal_paths {
+            let file = File::open(path).map_err(|e| {
+                Error::new(format!("'{}': {e}", path.display())).kind(ErrorKind::Io)
+            })?;
+            let mut reader = BufReader::new(file);
+            let mut line = String::new();
+
+            while reader.read_line(&mut line)? != 0 {
+                let trimmed = line.trim_end();
+                if let Some(rest) = trimmed.strip_prefix(BULLET) {
+                    write!(stdout, "{bullet_indent}")?;
+                    if cfg.output.show_hyphens {
+                        let prefix = cfg.output.example_prefix.paint(bullet_style);
+                        write!(stdout, "{prefix}")?;
+                    }
+                    writeln!(stdout, "{}", rest.paint(bullet_style))?;
+                } else if let Some(rest) = trimmed.strip_prefix(EXAMPLE) {
+                    if let Some(rest) = rest.strip_suffix('`') {
+                        writeln!(stdout, "{example_indent}{}", rest.paint(example_style))?;
+                    }
+                } else if trimmed.is_empty() && !cfg.output.compact {
+                    writeln!(stdout)?;
+                }
+                String::clear(&mut line);
+            }
+        }
+
+        if !cfg.output.compact {
+            writeln!(stdout)?;
+        }
+        Ok(stdout.flush()?)
     }
 
     /// Load the next line into the line buffer.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,9 @@
 use std::fs;
+use std::path::Path;
 use std::process::Command;
 
 use assert_cmd::prelude::*;
+use tempfile::tempdir;
 
 const TEST_PAGE: &str = "tests/data/page.md";
 const TEST_PAGE_OPTION_PLACEHOLDERS: &str = "tests/data/option-placeholder.md";
@@ -18,6 +20,57 @@ fn tlrc(cfg: &str, page: &str) -> Command {
     let mut cmd = Command::cargo_bin("tldr").unwrap();
     cmd.args(["--config", cfg, "--render", page]);
     cmd
+}
+
+fn run_git<P: AsRef<Path>>(cwd: P, args: &[&str]) {
+    let status = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {:?} failed", args);
+}
+
+fn init_remote_with_page<P: AsRef<Path>>(base: P, page_content: &str) -> String {
+    let base = base.as_ref();
+    let remote = base.join("remote.git");
+    let seed = base.join("seed");
+    fs::create_dir_all(&seed).unwrap();
+    run_git(base, &["init", "--bare", remote.to_str().unwrap()]);
+    run_git(base, &["init", seed.to_str().unwrap()]);
+    run_git(
+        &seed,
+        &["config", "user.email", "tldr-tests@example.invalid"],
+    );
+    run_git(&seed, &["config", "user.name", "tlrc tests"]);
+    fs::create_dir_all(seed.join("pages/common")).unwrap();
+    fs::write(seed.join("pages/common/foo.md"), page_content).unwrap();
+    run_git(&seed, &["add", "."]);
+    run_git(&seed, &["commit", "-m", "initial"]);
+    run_git(&seed, &["branch", "-M", "main"]);
+    run_git(
+        &seed,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    run_git(&seed, &["push", "-u", "origin", "main"]);
+    remote.to_string_lossy().into_owned()
+}
+
+fn make_cfg<P: AsRef<Path>>(path: P, cache: P, taps: &str) {
+    fs::write(
+        path,
+        format!(
+            r#"[cache]
+dir = "{}"
+auto_update = false
+languages = ["en"]
+
+{taps}
+"#,
+            cache.as_ref().display()
+        ),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -81,4 +134,398 @@ fn wrap_lines() {
     tlrc(CONFIG_LINE_WRAPPING, TEST_PAGE_LINE_WRAPPING)
         .assert()
         .stdout(expected);
+}
+
+#[test]
+fn append_personal_examples() {
+    let tmp = tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    fs::create_dir_all(cache_dir.join("pages.en/linux")).unwrap();
+    fs::create_dir_all(cache_dir.join("pages.en/common")).unwrap();
+    fs::create_dir_all(cache_dir.join("taps/personal/pages/common")).unwrap();
+
+    fs::write(
+        cache_dir.join("pages.en/linux/foo.md"),
+        "# foo\n\n> Test page.\n\n- Official example:\n\n`foo --official`\n",
+    )
+    .unwrap();
+    fs::write(
+        cache_dir.join("taps/personal/pages/common/foo.md"),
+        "# foo\n\n> Personal page.\n\n- Personal example:\n\n`foo --personal`\n",
+    )
+    .unwrap();
+
+    let cfg_path = tmp.path().join("config.toml");
+    fs::write(
+        &cfg_path,
+        format!(
+            r#"[cache]
+dir = "{}"
+auto_update = false
+languages = ["en"]
+
+[[taps]]
+name = "personal"
+url = "https://example.com/personal.git"
+enabled = true
+"#,
+            cache_dir.display()
+        ),
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("tldr").unwrap();
+    cmd.args([
+        "--config",
+        cfg_path.to_str().unwrap(),
+        "--platform",
+        "linux",
+        "foo",
+    ]);
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Personal additions"));
+    assert!(stdout.contains("foo --personal"));
+    assert!(!stdout.contains("Personal page."));
+}
+
+#[test]
+fn raw_mode_does_not_append_personal_examples() {
+    let tmp = tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    fs::create_dir_all(cache_dir.join("pages.en/linux")).unwrap();
+    fs::create_dir_all(cache_dir.join("taps/personal/pages/common")).unwrap();
+    fs::write(
+        cache_dir.join("pages.en/linux/foo.md"),
+        "# foo\n\n> Test page.\n\n- Official example:\n\n`foo --official`\n",
+    )
+    .unwrap();
+    fs::write(
+        cache_dir.join("taps/personal/pages/common/foo.md"),
+        "# foo\n\n> Personal page.\n\n- Personal example:\n\n`foo --personal`\n",
+    )
+    .unwrap();
+
+    let cfg_path = tmp.path().join("config.toml");
+    make_cfg(
+        &cfg_path,
+        &cache_dir,
+        r#"[[taps]]
+name = "personal"
+url = "https://example.com/personal.git"
+enabled = true"#,
+    );
+
+    let mut cmd = Command::cargo_bin("tldr").unwrap();
+    cmd.args([
+        "--config",
+        cfg_path.to_str().unwrap(),
+        "--platform",
+        "linux",
+        "--raw",
+        "foo",
+    ]);
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("# foo"));
+    assert!(!stdout.contains("Personal additions"));
+    assert!(!stdout.contains("foo --personal"));
+}
+
+#[test]
+fn tap_list_prints_empty_state() {
+    let tmp = tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let cfg_path = tmp.path().join("config.toml");
+    make_cfg(&cfg_path, &cache_dir, "");
+
+    let output = Command::cargo_bin("tldr")
+        .unwrap()
+        .args(["--config", cfg_path.to_str().unwrap(), "--tap-list"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(String::from_utf8(output.stdout)
+        .unwrap()
+        .contains("no taps configured"));
+}
+
+#[test]
+fn tap_add_list_remove_lifecycle() {
+    let tmp = tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let cfg_path = tmp.path().join("config.toml");
+    make_cfg(&cfg_path, &cache_dir, "");
+    let remote = init_remote_with_page(
+        tmp.path(),
+        "# foo\n\n> Remote page.\n\n- Example:\n\n`foo --from-remote`\n",
+    );
+
+    let add = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--tap-add",
+            "personal",
+            &remote,
+        ])
+        .output()
+        .unwrap();
+    assert!(add.status.success());
+    assert!(cache_dir.join("taps/personal/.git").is_dir());
+
+    let list = Command::cargo_bin("tldr")
+        .unwrap()
+        .args(["--config", cfg_path.to_str().unwrap(), "--tap-list"])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let listed = String::from_utf8(list.stdout).unwrap();
+    assert!(listed.contains("personal ->"));
+
+    let dup_add = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--tap-add",
+            "personal",
+            &remote,
+        ])
+        .output()
+        .unwrap();
+    assert!(!dup_add.status.success());
+
+    let remove = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--tap-remove",
+            "personal",
+        ])
+        .output()
+        .unwrap();
+    assert!(remove.status.success());
+    assert!(!cache_dir.join("taps/personal").exists());
+}
+
+#[test]
+fn tap_update_all_pulls_new_commit() {
+    let tmp = tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let cfg_path = tmp.path().join("config.toml");
+    make_cfg(&cfg_path, &cache_dir, "");
+    let remote = init_remote_with_page(
+        tmp.path(),
+        "# foo\n\n> Remote page.\n\n- First:\n\n`foo --first`\n",
+    );
+
+    let add = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--tap-add",
+            "personal",
+            &remote,
+        ])
+        .output()
+        .unwrap();
+    assert!(add.status.success());
+
+    // Push a second commit to the remote.
+    let work = tmp.path().join("work");
+    run_git(tmp.path(), &["clone", &remote, work.to_str().unwrap()]);
+    run_git(
+        &work,
+        &["config", "user.email", "tldr-tests@example.invalid"],
+    );
+    run_git(&work, &["config", "user.name", "tlrc tests"]);
+    fs::write(
+        work.join("pages/common/foo.md"),
+        "# foo\n\n> Remote page.\n\n- First:\n\n`foo --first`\n\n- Second:\n\n`foo --second`\n",
+    )
+    .unwrap();
+    run_git(&work, &["add", "."]);
+    run_git(&work, &["commit", "-m", "second"]);
+    run_git(&work, &["push"]);
+
+    let upd = Command::cargo_bin("tldr")
+        .unwrap()
+        .args(["--config", cfg_path.to_str().unwrap(), "--tap-update-all"])
+        .output()
+        .unwrap();
+    assert!(upd.status.success());
+
+    // Verify updated personal example shows up in rendered output.
+    fs::create_dir_all(cache_dir.join("pages.en/linux")).unwrap();
+    fs::write(
+        cache_dir.join("pages.en/linux/foo.md"),
+        "# foo\n\n> Official page.\n\n- Official:\n\n`foo --official`\n",
+    )
+    .unwrap();
+    let output = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--platform",
+            "linux",
+            "foo",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("foo --second"));
+}
+
+#[test]
+fn tap_update_single_pulls_new_commit() {
+    let tmp = tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let cfg_path = tmp.path().join("config.toml");
+    make_cfg(&cfg_path, &cache_dir, "");
+    let remote = init_remote_with_page(
+        tmp.path(),
+        "# foo\n\n> Remote page.\n\n- First:\n\n`foo --first`\n",
+    );
+
+    let add = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--tap-add",
+            "personal",
+            &remote,
+        ])
+        .output()
+        .unwrap();
+    assert!(add.status.success());
+
+    let work = tmp.path().join("work-one");
+    run_git(tmp.path(), &["clone", &remote, work.to_str().unwrap()]);
+    run_git(
+        &work,
+        &["config", "user.email", "tldr-tests@example.invalid"],
+    );
+    run_git(&work, &["config", "user.name", "tlrc tests"]);
+    fs::write(
+        work.join("pages/common/foo.md"),
+        "# foo\n\n> Remote page.\n\n- First:\n\n`foo --first`\n\n- Updated:\n\n`foo --updated`\n",
+    )
+    .unwrap();
+    run_git(&work, &["add", "."]);
+    run_git(&work, &["commit", "-m", "update"]);
+    run_git(&work, &["push"]);
+
+    let upd = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--tap-update",
+            "personal",
+        ])
+        .output()
+        .unwrap();
+    assert!(upd.status.success());
+
+    fs::create_dir_all(cache_dir.join("pages.en/linux")).unwrap();
+    fs::write(
+        cache_dir.join("pages.en/linux/foo.md"),
+        "# foo\n\n> Official page.\n\n- Official:\n\n`foo --official`\n",
+    )
+    .unwrap();
+    let output = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--platform",
+            "linux",
+            "foo",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("foo --updated"));
+}
+
+#[test]
+fn tap_update_unknown_fails() {
+    let tmp = tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let cfg_path = tmp.path().join("config.toml");
+    make_cfg(&cfg_path, &cache_dir, "");
+
+    let output = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--tap-update",
+            "missing",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn tap_remove_unknown_fails() {
+    let tmp = tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let cfg_path = tmp.path().join("config.toml");
+    make_cfg(&cfg_path, &cache_dir, "");
+
+    let output = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--tap-remove",
+            "missing",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+}
+
+#[test]
+fn tap_add_invalid_remote_does_not_persist() {
+    let tmp = tempdir().unwrap();
+    let cache_dir = tmp.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let cfg_path = tmp.path().join("config.toml");
+    make_cfg(&cfg_path, &cache_dir, "");
+    let invalid_remote = tmp.path().join("does-not-exist.git");
+
+    let add = Command::cargo_bin("tldr")
+        .unwrap()
+        .args([
+            "--config",
+            cfg_path.to_str().unwrap(),
+            "--tap-add",
+            "personal",
+            invalid_remote.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(!add.status.success());
+
+    let cfg = fs::read_to_string(&cfg_path).unwrap();
+    assert!(!cfg.contains("personal"));
 }

--- a/tldr.1
+++ b/tldr.1
@@ -39,6 +39,26 @@ List available languages. Use \fB--info\fR for a language list with more informa
 Show cache information (path, age, installed languages and the number of pages).
 .
 .TP 4
+.B --tap-list
+List configured personal repositories ("taps").
+.
+.TP 4
+\fB--tap-add\fR <NAME> <URL>
+Add a personal repository ("tap") and clone it.
+.
+.TP 4
+\fB--tap-remove\fR <NAME>
+Remove a configured personal repository ("tap") and its local checkout.
+.
+.TP 4
+\fB--tap-update\fR <NAME>
+Update a configured personal repository ("tap").
+.
+.TP 4
+.B --tap-update-all
+Update all enabled personal repositories ("taps").
+.
+.TP 4
 \fB-r, --render\fR <FILE>
 Render the specified markdown file.
 .
@@ -115,7 +135,8 @@ Do not strip empty lines from output. Equivalent of setting\&
 .TP 4
 .B -R, --raw
 Print pages in raw markdown. Equivalent of setting\&
-\fIoutput.raw_markdown\fR=\fBtrue\fR in the config.
+\fIoutput.raw_markdown\fR=\fBtrue\fR in the config.\&
+Personal tap additions are not appended in raw mode.
 .
 .TP 4
 .B --no-raw


### PR DESCRIPTION
Please see https://github.com/tldr-pages/tldr/issues/21278 what this is about.

- Bumped the client specification version from 2.3 to 2.4 in `build.rs`.
- Enhanced `README.md` with documentation on configuring personal repositories ("taps") and added command examples.
- Updated `tldr.1` man page to include new commands for managing taps: `--tap-list`, `--tap-add`, `--tap-remove`, and `--tap-update`.
- Modified `args.rs` to include new CLI arguments for tap management.
- Implemented functionality in `cache.rs` to sync and manage personal repository taps.
- Updated `config.rs` to define the `TapConfig` structure for tap configuration.
- Enhanced `main.rs` to handle tap-related commands and integrate them into the existing workflow.
- Updated output rendering in `output.rs` to display personal additions from taps.
- Added tests in `tests.rs` to verify tap management functionality.

This commit introduces a significant feature that allows users to manage their own repositories of examples, enhancing the flexibility and usability of the client.