### PR TITLE
Merge output mode options into a single one

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -97,19 +97,19 @@ pub struct Cli {
     #[arg(short, long)]
     pub offline: bool,
 
-    /// Strip empty lines from output.
+    /// [DEPRECATED] Strip empty lines from output.
     #[arg(short, long)]
     pub compact: bool,
 
-    /// Do not strip empty lines from output (overrides --compact).
+    /// [DEPRECATED] Do not strip empty lines from output (overrides --compact).
     #[arg(long)]
     pub no_compact: bool,
 
-    /// Print pages in raw markdown instead of rendering them.
+    /// Print pages in raw Markdown instead of rendering them.
     #[arg(short = 'R', long)]
     pub raw: bool,
 
-    /// Render pages instead of printing raw file contents (overrides --raw).
+    /// [DEPRECATED] Render pages instead of printing raw file contents (overrides --raw).
     #[arg(long)]
     pub no_raw: bool,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -264,9 +264,25 @@ pub enum OptionStyle {
     Both,
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputMode {
+    #[default]
+    /// All empty lines included.
+    Normal,
+    /// Empty lines after example descriptions removed.
+    Compact,
+    /// All empty lines removed.
+    VeryCompact,
+    /// Raw markdown.
+    Raw,
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct OutputConfig {
+    /// How to output pages.
+    pub mode: OutputMode,
     /// Show the page title.
     pub show_title: bool,
     /// Show the platform in the title.
@@ -279,26 +295,32 @@ pub struct OutputConfig {
     pub example_prefix: Cow<'static, str>,
     /// Set the max line length. 0 means to use the terminal width.
     pub line_length: usize,
+
+    /// _**DEPRECATED:**_ replaced by `mode = "compact"`
     /// Strip empty lines from pages.
-    pub compact: bool,
+    pub compact: Option<bool>,
+
     /// Display the specified options in pages wherever possible.
     pub option_style: OptionStyle,
+
+    /// _**DEPRECATED:**_ replaced by `mode = "raw"`
     /// Print pages in raw markdown.
-    pub raw_markdown: bool,
+    pub raw_markdown: Option<bool>,
 }
 
 impl Default for OutputConfig {
     fn default() -> Self {
         Self {
+            mode: OutputMode::Normal,
             show_title: true,
             platform_title: false,
             show_hyphens: false,
             edit_link: false,
             example_prefix: Cow::Borrowed("- "),
             line_length: 0,
-            compact: false,
+            compact: None,
             option_style: OptionStyle::default(),
-            raw_markdown: false,
+            raw_markdown: None,
         }
     }
 }
@@ -339,6 +361,38 @@ impl Config {
         })?)?)
     }
 
+    fn convert_deprecated_opts_to_new(&mut self) {
+        if self.output.compact.is_some() || self.output.raw_markdown.is_some() {
+            warn!(
+                "deprecated option(s) detected in the config.\n\
+                The old options will be removed in the future, please\n\
+                replace them with the appropriate new options.\n\
+                See the warnings below and v1.14.0 release notes for more information."
+            );
+        }
+
+        if let Some(b) = self.output.compact {
+            warn!(
+                "output.compact = {b} is deprecated.\n\
+                Please use output.mode = \"{}\" instead",
+                if b { "very_compact" } else { "normal" }
+            );
+            if b && self.output.mode == OutputMode::default() {
+                self.output.mode = OutputMode::VeryCompact;
+            }
+        }
+        if let Some(b) = self.output.raw_markdown {
+            warn!(
+                "output.raw_markdown = {b} is deprecated.\n\
+                Please use output.mode = \"{}\" instead",
+                if b { "raw" } else { "normal" }
+            );
+            if b && self.output.mode == OutputMode::default() {
+                self.output.mode = OutputMode::Raw;
+            }
+        }
+    }
+
     pub fn new(cli_config_path: Option<&Path>) -> Result<Self> {
         let cfg_res = if let Some(path) = cli_config_path {
             if path.is_file() {
@@ -372,6 +426,8 @@ impl Config {
                 p.extend(cfg.cache.dir.components().skip(1));
                 cfg.cache.dir = p;
             }
+
+            cfg.convert_deprecated_opts_to_new();
             cfg
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use yansi::Paint;
 
 use crate::args::Cli;
 use crate::cache::Cache;
-use crate::config::{Config, OptionStyle};
+use crate::config::{Config, OptionStyle, OutputMode};
 use crate::error::{Error, Result};
 use crate::output::PageRenderer;
 use crate::util::{Logger, init_color};
@@ -48,9 +48,33 @@ fn main() -> ExitCode {
 }
 
 fn include_cli_in_config(cfg: &mut Config, cli: &Cli) {
+    if cli.compact {
+        warn!(
+            "--compact is deprecated.\nPlease use output.mode = \"very_compact\" in the config instead"
+        );
+        cfg.output.mode = OutputMode::VeryCompact;
+    }
+    if cli.no_compact {
+        warn!(
+            "--no-compact is deprecated.\nPlease use output.mode = \"normal\" in the config instead"
+        );
+        if cfg.output.mode == OutputMode::VeryCompact {
+            cfg.output.mode = OutputMode::Normal;
+        }
+    }
+
+    if cli.raw {
+        cfg.output.mode = OutputMode::Raw;
+    }
+    if cli.no_raw {
+        warn!("--no-raw is deprecated.\nPlease use output.mode = \"normal\" in the config instead");
+        if cfg.output.mode == OutputMode::Raw {
+            cfg.output.mode = OutputMode::Normal;
+        }
+    }
+
     cfg.output.edit_link |= cli.edit;
-    cfg.output.compact = !cli.no_compact && (cli.compact || cfg.output.compact);
-    cfg.output.raw_markdown = !cli.no_raw && (cli.raw || cfg.output.raw_markdown);
+
     match (cli.short_options, cli.long_options) {
         (false, false) => {}
         (true, true) => cfg.output.option_style = OptionStyle::Both,

--- a/src/output.rs
+++ b/src/output.rs
@@ -9,7 +9,7 @@ use terminal_size::terminal_size;
 use unicode_width::UnicodeWidthStr;
 use yansi::{Paint, Style};
 
-use crate::config::{Config, OptionStyle};
+use crate::config::{Config, OptionStyle, OutputMode};
 use crate::error::{Error, ErrorKind, Result};
 use crate::util::PagePathExt;
 
@@ -276,7 +276,7 @@ impl<'a> PageRenderer<'a> {
         let mut page = File::open(path)
             .map_err(|e| Error::new(format!("'{}': {e}", path.display())).kind(ErrorKind::Io))?;
 
-        if cfg.output.raw_markdown {
+        if cfg.output.mode == OutputMode::Raw {
             io::copy(&mut page, &mut io::stdout()).map_err(|e| {
                 Error::new(format!("'{}': {e}", path.display())).kind(ErrorKind::Io)
             })?;
@@ -427,6 +427,12 @@ impl<'a> PageRenderer<'a> {
         }
         writeln!(self.stdout, "{bullet}")?;
 
+        if self.cfg.output.mode == OutputMode::Compact {
+            // Next line must be empty.
+            self.reader.skip_until(b'\n')?;
+            self.lnum += 1;
+        }
+
         Ok(())
     }
 
@@ -461,12 +467,11 @@ impl<'a> PageRenderer<'a> {
         Ok(())
     }
 
-    /// Write a newline to the page buffer if compact mode is not turned on.
+    /// Write a newline to the page buffer if very compact mode is not turned on.
     fn add_newline(&mut self) -> Result<()> {
-        if !self.cfg.output.compact {
-            writeln!(self.stdout)?;
+        if self.cfg.output.mode != OutputMode::VeryCompact {
+            self.stdout.write_all(b"\n")?;
         }
-
         Ok(())
     }
 


### PR DESCRIPTION
Since all the mode options are mutually exclusive `bool`s, I decided to deprecate the previous options and merge them into one: `output.mode = "normal|compact|very_compact|raw"`.

`normal` is equivalent to `compact = false` & `raw_markdown = false`
`compact` is a new mode requested in #147 that only removes newlines after example descriptions
`very_compact` is the old `compact` option, equivalent to `compact = true`
`raw` is equivalent to `raw_markdown = true`


All old options still work as before (for now), but warnings are emitted to make people switch to the new option.

`--compact` and `--no-compact` are also deprecated, because their names no longer reflect the config options.
`--no-raw` is deprecated because I doubt anyone sets the default mode to raw Markdown, and this is the only scenario where this option is useful. I guess this can be re-added if users ask for it.

This is how pages are displayed with `output.mode = "compact"`:

<img width="556" height="230" alt="compact" src="https://github.com/user-attachments/assets/4e6edbe4-496e-47e2-93ea-769b8cc96761" />

Closes #147.