### PR TITLE
README: Add Conda installation instructions for tlrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ Install [tlrc](https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/pkgsrc/net/tlrc/
 pkgin install tlrc
 ```
 
+### Linux/macOS/Windows using Conda
+
+Install [tlrc](https://anaconda.org/channels/conda-forge/packages/tlrc/overview) with Conda:
+
+```shell
+conda install conda-forge::tlrc
+# if using mamba
+# mamba install conda-forge::tlrc
+```
+
 ### From crates.io
 
 To build [tlrc][crate] from a source tarball, run:


### PR DESCRIPTION
Hi, if you don't mind, I made a conda-forge [feedstock](https://github.com/conda-forge/tlrc-feedstock) for [tlrc](https://anaconda.org/channels/conda-forge/packages/tlrc/overview).  The submission has been merged by conda-forge and is now available. It is cross-platform, with Linux, macOS, and Windows builds available (for both amd64 and aarch64).

If you have Conda or Mamba installed, you can try it out:
```shell
conda install conda-forge::tlrc
# if using mamba
# mamba install conda-forge::tlrc
```